### PR TITLE
トーストのアクセントカラーをキャッシュして TL 以外でも正しい色を表示

### DIFF
--- a/build.js
+++ b/build.js
@@ -299,6 +299,27 @@ function buildUserscript() {
     "localStorage.setItem('twblock_icons', JSON.stringify({ block: BLOCK_ICON, mute: MUTE_ICON }));"
   );
 
+  // Replace chrome.storage.local.get('accentColor', ...) with localStorage
+  transformed = transformed.replace(
+    /function loadStoredAccentColor\(\) \{[\s\S]*?return new Promise[\s\S]*?\}\);\s*\}\)/,
+    `function loadStoredAccentColor() {
+    return new Promise((resolve) => {
+      try {
+        const stored = localStorage.getItem('twblock_accentColor');
+        if (stored && ACCENT_COLORS.has(stored)) {
+          cachedAccentColor = stored;
+        }
+      } catch {}
+      resolve();
+    })`
+  );
+
+  // Replace chrome.storage.local.set for accentColor
+  transformed = transformed.replace(
+    /chrome\.storage\.local\.set\(\{ accentColor: bg \}\);/g,
+    "localStorage.setItem('twblock_accentColor', bg);"
+  );
+
   // Inject CSS function
   const cssInjector = `
   // ---- CSS注入 ----

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "browser_specific_settings": {


### PR DESCRIPTION
TL のタブ要素からアクセントカラーを取得できるのは TL ページのみだったため、
一度取得した色を chrome.storage.local に保存し、取得できないページでは
キャッシュから使用するように変更。ユーザースクリプト版も対応。

https://claude.ai/code/session_01X2L6XUpDoNX1ZhctC19YB6