### PR TITLE
[Follow-up] プロフィールのFollow操作でDOM再配置しないよう修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -736,21 +736,17 @@
       }
       if (!followChild) return;
 
-      const wrapper = document.createElement('div');
-      wrapper.className = 'twblock-follow-wrapper';
-      targetRow.insertBefore(wrapper, followChild);
-      wrapper.appendChild(buttons);
-      wrapper.appendChild(followChild);
-
-      // Followボタン親のmargin-leftをリセット（X側の12pxが余計）
-      followChild.style.marginLeft = '0';
+      // React管理下のFollowボタンをreparentすると
+      // プロフィールで「Something went wrong」が出る場合があるため、
+      // FollowボタンのDOMは動かさず twblock ボタンのみを挿入する。
+      targetRow.insertBefore(buttons, followChild);
 
       if (isProfile) {
         // ボタンコンテナを上揃えにして⋯/Followと縦位置を合わせる
         buttons.style.alignSelf = 'flex-start';
         // gapを⋯のmargin-right(8px)に揃える
         buttons.style.gap = '8px';
-        wrapper.style.gap = '8px';
+        buttons.style.marginRight = '8px';
       }
     });
   }

--- a/styles.css
+++ b/styles.css
@@ -1,18 +1,5 @@
 /* ========== Twitter 1Click Block & Mute ========== */
 
-/* Followボタン + twblockボタンのラッパー */
-.twblock-follow-wrapper {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  flex-shrink: 0;
-}
-
-/* ラッパー内のFollowボタン親のmargin-leftをリセット */
-.twblock-follow-wrapper > :not(.twblock-btn-container) {
-  margin-left: 0 !important;
-}
-
 /* ボタンコンテナ（共通） */
 .twblock-btn-container {
   display: flex;


### PR DESCRIPTION
### Motivation
- プロフィール上で拡張が `Follow` ボタン要素をラップ・再配置（reparent）していたため、React 管理下のノードが不整合を起こし「Something went wrong」が発生する可能性があったため修正。

### Description
- `content.js`: プロフィール領域では `Follow` ノードを移動せず、拡張の `twblock` ボタンのみを `Follow` 要素の直前に挿入するように変更し、reparent 処理を削除した。表示調整は `buttons.style.marginRight` と `buttons.style.gap` で吸収している。
- `styles.css`: もはや不要になった `.twblock-follow-wrapper` 関連のスタイルを削除して実装と整合させた。

### Testing
- ビルド検証として `node build.js zip` を実行し、ZIP の生成が成功して `twitter-block-v1.3.5.zip` が作成されることを確認した（成功）。
- ローカル差分確認と簡易動作検査を行い、変更が期待どおりに反映されていることを確認した（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf242c91c83319a339cd5018feef8)