### PR TITLE
Include Korean mute icon signature (f46a0eeb) in signature matching

### DIFF
--- a/content.js
+++ b/content.js
@@ -24,7 +24,7 @@
   const ICON_DEBUG_STORAGE_KEY = 'twblock:debug-icons';
   const MAX_ICON_DEBUG_HISTORY = 20;
   const BLOCK_ICON_SIGNATURES = new Set(['498278e7']);
-  const MUTE_ICON_SIGNATURES = new Set(['d3853445']);
+  const MUTE_ICON_SIGNATURES = new Set(['d3853445', 'f46a0eeb']);
   const ICON_SHAPE_ATTRS = {
     path: ['d', 'transform', 'fill-rule', 'clip-rule', 'stroke-width', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit'],
     circle: ['cx', 'cy', 'r', 'transform', 'stroke-width'],


### PR DESCRIPTION
### Motivation
- The Korean UI uses an alternate mute icon signature (`f46a0eeb`) which was not present in the `MUTE_ICON_SIGNATURES` whitelist, causing signature-based mute detection to fail in that environment.

### Description
- Added `'f46a0eeb'` to `MUTE_ICON_SIGNATURES` in `content.js` while keeping the existing `'d3853445'` entry, and committed the change as `bcc0b41`.

### Testing
- Ran `node --check content.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f452dca788331bf0b903f55d48a5f)